### PR TITLE
fix(validation): assume empty array is a list, not a map

### DIFF
--- a/php/src/Authr.php
+++ b/php/src/Authr.php
@@ -157,7 +157,7 @@ final class Authr implements AuthrInterface
      */
     private function validateRuleConditionSet($conditions)
     {
-        if (static::isMap($conditions)) {
+        if (static::isMap($conditions, static::EMPTY_IS_NOT_ASSOCIATIVE)) {
             $haveCondKeys = array_keys($conditions);
             if (count($haveCondKeys) > 1) {
                 $otherKeys = implode("', '", array_values(array_filter($haveCondKeys, function ($key) { return $key !== '$or' && $key !== '$and'; })));


### PR DESCRIPTION
This is a fully valid rule:
```json
{
    "access": "allow",
    "where": {
        "action": "delete",
        "rsrc_type": "zone",
        "rsrc_match": []
    }
}
```

But PHP didn't think so, because it interpreted the empty array (`[]`) as an empty map (`{}`). Just a quick mode on the map detector that tells it that empty should be interpreted as a list.