### PR TITLE
feat: adding "authrutil" Go package with handy StructResource

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,21 @@ matrix:
       go: '1.11'
       script:
         - go get -t .
-        - go test -race -v -coverprofile=/dev/null .
+        - go test -race -v -coverprofile=/dev/null ./...
         # go 1.11 runs "vet" by default with go test
     - language: go
       go: '1.10'
-      script: &go_script
+      script:
         - go get -t .
         - go vet
-        - go test -race -v -coverprofile=/dev/null .
+        - go test -race -v -coverprofile=/dev/null ./...
     - language: go
       go: '1.9'
-      script: *go_script
+      script:
+        - go get -t .
+        - go vet
+        - go test -race -v ./...
+        # go 1.9 does not support coverprofile over multiple packages
     - language: php
       php: '7.1'
       script: &php_script

--- a/authrutil/struct_resource.go
+++ b/authrutil/struct_resource.go
@@ -1,0 +1,42 @@
+package authrutil
+
+import (
+	"reflect"
+	"regexp"
+
+	"github.com/cloudflare/authr"
+)
+
+var exportedField = regexp.MustCompile("^[A-Z]")
+
+type structResource struct {
+	typ string
+	v   reflect.Value
+}
+
+func (s structResource) GetResourceType() (string, error) {
+	return s.typ, nil
+}
+
+func (s structResource) GetResourceAttribute(key string) (interface{}, error) {
+	if !exportedField.MatchString(key) {
+		return nil, nil
+	}
+	f, ok := s.v.Type().FieldByName(key)
+	if !ok {
+		return nil, nil
+	}
+	return s.v.FieldByIndex(f.Index).Interface(), nil
+}
+
+var _ authr.Resource = structResource{}
+
+// StructResource accepts a string that indicates the "rsrc_type" of a resource,
+// and the struct that needs to be acceptable as an authr.Resource. This
+// function will panic if v is NOT a struct.
+func StructResource(typ string, v interface{}) authr.Resource {
+	if reflect.TypeOf(v).Kind() != reflect.Struct {
+		panic("authrutil.StructResource provided with a non-struct value")
+	}
+	return structResource{typ: typ, v: reflect.ValueOf(v)}
+}

--- a/authrutil/struct_resource_test.go
+++ b/authrutil/struct_resource_test.go
@@ -1,0 +1,49 @@
+package authrutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStructResource(t *testing.T) {
+	t.Run("should panic if given a non-struct value", func(t *testing.T) {
+		require.Panics(t, func() {
+			StructResource("a", 5)
+		})
+	})
+	t.Run("should return the provided resource type", func(t *testing.T) {
+		rt, err := StructResource("a", struct{}{}).GetResourceType()
+		require.Nil(t, err)
+		require.Equal(t, "a", rt)
+	})
+	t.Run("should retrieve correct values from struct", func(t *testing.T) {
+		sr := StructResource("thing", struct {
+			Foo int
+			Bar string
+		}{Foo: 5, Bar: "boom!"})
+		avfoo, err := sr.GetResourceAttribute("Foo")
+		require.Nil(t, err)
+		require.Equal(t, 5, avfoo.(int))
+		avbar, err := sr.GetResourceAttribute("Bar")
+		require.Nil(t, err)
+		require.Equal(t, "boom!", avbar.(string))
+	})
+	t.Run("should return <nil> for non-existant struct fields", func(t *testing.T) {
+		sr := StructResource("thing", struct {
+			Foo int
+			Bar string
+		}{Foo: 7, Bar: "bam!"})
+		avne, err := sr.GetResourceAttribute("Baz")
+		require.Nil(t, err)
+		require.Nil(t, avne)
+	})
+	t.Run("should not be able to read un-exported stuct fields", func(t *testing.T) {
+		sr := StructResource("thing", struct {
+			foo int
+		}{foo: 9})
+		avnil, err := sr.GetResourceAttribute("foo")
+		require.Nil(t, err)
+		require.Nil(t, avnil)
+	})
+}


### PR DESCRIPTION
this new function will allow implementations of the Go authr library to easily
take their structs and easily turn them into valid resources in authr.